### PR TITLE
Switch TTS to Groq PlayAI voices

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -32,7 +32,7 @@ GROQ_API_KEY=your_groq_api_key_here
 USE_BYO_LLM=true  # Set to false for Deepgram's standard LLM
 
 # Voice Configuration
-AGENT_VOICE_NAME=aura-2-thalia-en
+AGENT_VOICE_NAME=Cheyenne-PlayAI
 AGENT_PROMPT_PATH=prompts/system_prompt.txt
 
 # Audio Configuration (optional)
@@ -89,11 +89,26 @@ python main.py
 
 ## Available Voice Models
 
-The agent supports all Deepgram Aura-2 voices:
-- `aura-2-thalia-en` (default) - Clear, Confident, Energetic
-- `aura-2-cora-en` - Smooth, Melodic, Caring
-- `aura-2-luna-en` - Friendly, Natural, Engaging
-- And 35+ other voices...
+The agent now supports Groq Play-AI voices:
+- `Arista-PlayAI`
+- `Atlas-PlayAI`
+- `Basil-PlayAI`
+- `Briggs-PlayAI`
+- `Calum-PlayAI`
+- `Celeste-PlayAI`
+- `Cheyenne-PlayAI` *(default)*
+- `Chip-PlayAI`
+- `Cillian-PlayAI`
+- `Deedee-PlayAI`
+- `Fritz-PlayAI`
+- `Gail-PlayAI`
+- `Indigo-PlayAI`
+- `Mamaw-PlayAI`
+- `Mason-PlayAI`
+- `Mikail-PlayAI`
+- `Mitch-PlayAI`
+- `Quinn-PlayAI`
+- `Thunder-PlayAI`
 
 ## Performance Comparison
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Re:MEMBER AI Voice Agent
 
-A powerful AI voice agent using Deepgram's Voice Agent API with support for BYO (Bring Your Own) LLM integration. Features ultra-fast voice conversations with real-time STT, LLM, and TTS processing for natural interactions.
+A powerful AI voice agent using Groq Play-AI voices with support for BYO (Bring Your Own) LLM integration. Features ultra-fast voice conversations with real-time STT, LLM, and TTS processing for natural interactions.
 
 ## Key Features
 

--- a/app.py
+++ b/app.py
@@ -224,92 +224,56 @@ def test_audio(input_device, output_device):
 
 # Step 3: Voice picker (choices list only – actual components are created inside the layout)
 voices = [
-    {"name": "aura-2-amalthea-en", "gender": "Female", "characteristics": "Engaging, Natural, Cheerful"},
-    {"name": "aura-2-andromeda-en", "gender": "Female", "characteristics": "Casual, Expressive, Comfortable"},
-    {"name": "aura-2-apollo-en", "gender": "Male", "characteristics": "Confident, Comfortable, Casual"},
-    {"name": "aura-2-arcas-en", "gender": "Male", "characteristics": "Natural, Smooth, Clear, Comfortable"},
-    {"name": "aura-2-aries-en", "gender": "Male", "characteristics": "Warm, Energetic, Caring"},
-    {"name": "aura-2-asteria-en", "gender": "Female", "characteristics": "Clear, Confident, Knowledgeable, Energetic"},
-    {"name": "aura-2-athena-en", "gender": "Female", "characteristics": "Calm, Smooth, Professional"},
-    {"name": "aura-2-atlas-en", "gender": "Male", "characteristics": "Enthusiastic, Confident, Approachable, Friendly"},
-    {"name": "aura-2-aurora-en", "gender": "Female", "characteristics": "Cheerful, Expressive, Energetic"},
-    {"name": "aura-2-callista-en", "gender": "Female", "characteristics": "Clear, Energetic, Professional, Smooth"},
-    {"name": "aura-2-cora-en", "gender": "Female", "characteristics": "Smooth, Melodic, Caring"},
-    {"name": "aura-2-cordelia-en", "gender": "Female", "characteristics": "Approachable, Warm, Polite"},
-    {"name": "aura-2-delia-en", "gender": "Female", "characteristics": "Casual, Friendly, Cheerful, Breathy"},
-    {"name": "aura-2-draco-en", "gender": "Male", "characteristics": "Warm, Approachable, Trustworthy, Baritone"},
-    {"name": "aura-2-electra-en", "gender": "Female", "characteristics": "Professional, Engaging, Knowledgeable"},
-    {"name": "aura-2-harmonia-en", "gender": "Female", "characteristics": "Empathetic, Clear, Calm, Confident"},
-    {"name": "aura-2-helena-en", "gender": "Female", "characteristics": "Caring, Natural, Positive, Friendly, Raspy"},
-    {"name": "aura-2-hera-en", "gender": "Female", "characteristics": "Smooth, Warm, Professional"},
-    {"name": "aura-2-hermes-en", "gender": "Male", "characteristics": "Expressive, Engaging, Professional"},
-    {"name": "aura-2-hyperion-en", "gender": "Male", "characteristics": "Caring, Warm, Empathetic"},
-    {"name": "aura-2-iris-en", "gender": "Female", "characteristics": "Cheerful, Positive, Approachable"},
-    {"name": "aura-2-janus-en", "gender": "Female", "characteristics": "Southern, Smooth, Trustworthy"},
-    {"name": "aura-2-juno-en", "gender": "Female", "characteristics": "Natural, Engaging, Melodic, Breathy"},
-    {"name": "aura-2-jupiter-en", "gender": "Male", "characteristics": "Expressive, Knowledgeable, Baritone"},
-    {"name": "aura-2-luna-en", "gender": "Female", "characteristics": "Friendly, Natural, Engaging"},
-    {"name": "aura-2-mars-en", "gender": "Male", "characteristics": "Smooth, Patient, Trustworthy, Baritone"},
-    {"name": "aura-2-minerva-en", "gender": "Female", "characteristics": "Positive, Friendly, Natural"},
-    {"name": "aura-2-neptune-en", "gender": "Male", "characteristics": "Professional, Patient, Polite"},
-    {"name": "aura-2-odysseus-en", "gender": "Male", "characteristics": "Calm, Smooth, Comfortable, Professional"},
-    {"name": "aura-2-ophelia-en", "gender": "Female", "characteristics": "Expressive, Enthusiastic, Cheerful"},
-    {"name": "aura-2-orion-en", "gender": "Male", "characteristics": "Approachable, Comfortable, Calm, Polite"},
-    {"name": "aura-2-orpheus-en", "gender": "Male", "characteristics": "Professional, Clear, Confident, Trustworthy"},
-    {"name": "aura-2-pandora-en", "gender": "Female", "characteristics": "Smooth, Calm, Melodic, Breathy"},
-    {"name": "aura-2-phoebe-en", "gender": "Female", "characteristics": "Energetic, Warm, Casual"},
-    {"name": "aura-2-pluto-en", "gender": "Male", "characteristics": "Smooth, Calm, Empathetic, Baritone"},
-    {"name": "aura-2-saturn-en", "gender": "Male", "characteristics": "Knowledgeable, Confident, Baritone"},
-    {"name": "aura-2-selene-en", "gender": "Female", "characteristics": "Expressive, Engaging, Energetic"},
-    {"name": "aura-2-thalia-en", "gender": "Female", "characteristics": "Clear, Confident, Energetic, Enthusiastic"},
-    {"name": "aura-2-theia-en", "gender": "Female", "characteristics": "Expressive, Polite, Sincere"},
-    {"name": "aura-2-vesta-en", "gender": "Female", "characteristics": "Natural, Expressive, Patient, Empathetic"},
-    {"name": "aura-2-zeus-en", "gender": "Male", "characteristics": "Deep, Trustworthy, Smooth"},
+    {"name": "Arista-PlayAI"},
+    {"name": "Atlas-PlayAI"},
+    {"name": "Basil-PlayAI"},
+    {"name": "Briggs-PlayAI"},
+    {"name": "Calum-PlayAI"},
+    {"name": "Celeste-PlayAI"},
+    {"name": "Cheyenne-PlayAI"},
+    {"name": "Chip-PlayAI"},
+    {"name": "Cillian-PlayAI"},
+    {"name": "Deedee-PlayAI"},
+    {"name": "Fritz-PlayAI"},
+    {"name": "Gail-PlayAI"},
+    {"name": "Indigo-PlayAI"},
+    {"name": "Mamaw-PlayAI"},
+    {"name": "Mason-PlayAI"},
+    {"name": "Mikail-PlayAI"},
+    {"name": "Mitch-PlayAI"},
+    {"name": "Quinn-PlayAI"},
+    {"name": "Thunder-PlayAI"},
 ]
 
 # Default voice is now Cora
-DEFAULT_VOICE = "aura-2-cora-en"
+DEFAULT_VOICE = "Cheyenne-PlayAI"
 
 # Helper to turn model name like "aura-2-thalia-en" into "Thalia"
 def display_name(model_name: str) -> str:
-    try:
-        return model_name.split("-")[-2].title()
-    except Exception:
-        return model_name
+    """Nicely format a PlayAI voice name."""
+    if model_name.endswith("-PlayAI"):
+        return model_name.replace("-PlayAI", "")
+    return model_name
 
 def update_voice_details(selected):
     for v in voices:
         if v["name"] == selected:
-            details = f"{display_name(v['name'])} - {v['gender']} - {v['characteristics']}"
+            details = display_name(v["name"])
             return details, None  # preview audio set via button
     return "", None
 
 def play_preview(voice):
-    """Generate a short Deepgram TTS sample for the selected voice."""
-    import requests, io, numpy as np, soundfile as sf, os
-
-    api_key = os.getenv("DEEPGRAM_API_KEY")
-    if not api_key:
-        print("DEEPGRAM_API_KEY not set – cannot generate preview")
-        return None
+    """Generate a short Groq Play-AI TTS sample for the selected voice."""
+    import io, numpy as np, soundfile as sf
+    from groq_tts import synthesize_speech
 
     try:
-        tts_url = "https://api.deepgram.com/v1/speak"
-        params = {
-            "model": voice,
-            "encoding": "linear16",
-            "sample_rate": "48000",
-        }
-        payload = {"text": "Hello, I am the selected Remember voice agent."}
-        headers = {
-            "Authorization": f"Token {api_key}",
-            "Content-Type": "application/json",
-        }
-        resp = requests.post(tts_url, params=params, headers=headers, json=payload, timeout=15)
-        resp.raise_for_status()
-
-        wav_bytes = io.BytesIO(resp.content)
-        audio_np, sr = sf.read(wav_bytes, dtype="int16")
+        wav_bytes = synthesize_speech(
+            "Hello, I am the selected Remember voice agent.",
+            voice=voice,
+        )
+        buffer = io.BytesIO(wav_bytes)
+        audio_np, sr = sf.read(buffer, dtype="int16")
         return (sr, audio_np)
     except Exception as e:
         print(f"Preview generation failed: {e}")
@@ -520,7 +484,7 @@ with gr.Blocks(title="Re:MEMBER AI Voice Agent Demo", theme=gr.themes.Soft(prima
                 # Dropdown now shows full voice details (Name - Gender - Characteristics)
                 voice_dropdown = gr.Dropdown(
                     choices=[(
-                        f"{display_name(v['name'])} - {v['gender']} - {v['characteristics']}",
+                        display_name(v['name']),
                         v['name']
                     ) for v in voices],
                     label="Select Agent Voice",

--- a/app_launcher.py
+++ b/app_launcher.py
@@ -54,7 +54,7 @@ def setup_embedded_environment():
     os.environ["USE_BYO_LLM"] = "True"  # Re-enabled with proper Deepgram BYO LLM format
     
     # Voice configuration
-    os.environ["AGENT_VOICE_NAME"] = "aura-2-cora-en"
+    os.environ["AGENT_VOICE_NAME"] = "Cheyenne-PlayAI"
     
     # Audio configuration  
     os.environ["DG_START_THRESHOLD"] = "24"

--- a/config_defaults.py
+++ b/config_defaults.py
@@ -420,7 +420,7 @@ class TTSConfig:
     
     # GROQ TTS settings
     MODEL_NAME = "playai-tts"              # GROQ's TTS model
-    VOICE_NAME = "Fritz-PlayAI"            # Professional male voice
+    VOICE_NAME = "Cheyenne-PlayAI"         # Default PlayAI voice
     RESPONSE_FORMAT = "wav"                # Audio format
     
     # Playback settings

--- a/demo_mode_GROQ_deepgram_voice_agent.py
+++ b/demo_mode_GROQ_deepgram_voice_agent.py
@@ -690,9 +690,9 @@ class DeepgramVoiceAgentPipeline:
                     options.agent.think.provider["model"] = "gpt-4o-mini"
                     print("  ✅ Using minimal fallback LLM configuration")
             
-            # TTS configuration (Always Deepgram Aura for now)
-            options.agent.speak.provider.type = "deepgram"
-            voice_name = os.getenv("AGENT_VOICE_NAME", "aura-2-thalia-en")
+            # TTS configuration now uses Groq Play-AI
+            options.agent.speak.provider.type = "open_ai"
+            voice_name = os.getenv("AGENT_VOICE_NAME", "Cheyenne-PlayAI")
             options.agent.speak.provider.model = voice_name
             
             # Set TTS rate
@@ -1407,30 +1407,19 @@ async def run_voice_agent(user_pcm: bytes) -> tuple[str, bytes]:
         reply_text = "Sorry, I had trouble thinking of a reply."
         print(f"Groq completion failed: {exc}")
 
-    # 4) Text-to-Speech with Deepgram Aura-2 -----------------------------------
+    # 4) Text-to-Speech with Groq Play-AI --------------------------------------
     try:
-        tts_url = "https://api.deepgram.com/v1/speak"
-        # Use the same voice model as the real-time pipeline for consistency
-        params = {
-            "model": os.getenv("AGENT_VOICE_NAME", "aura-2-thalia-en"),
-            "encoding": "linear16",
-            "sample_rate": "48000"
-        }
-        headers = {
-            "Authorization": f"Token {DEEPGRAM_API_KEY}",
-            "Content-Type": "application/json"
-        }
-        tts_payload = {"text": reply_text}
-        loop = asyncio.get_event_loop()
-        # Run blocking request in a thread so we don't block the event loop
-        def _blocking_tts():
-            resp = _requests.post(tts_url, params=params, headers=headers, json=tts_payload)
-            resp.raise_for_status()
-            return resp.content
-        reply_pcm = await loop.run_in_executor(None, _blocking_tts)
+        from groq_tts import synthesize_speech
+        wav_bytes = synthesize_speech(
+            reply_text,
+            voice=os.getenv("AGENT_VOICE_NAME", "Cheyenne-PlayAI"),
+        )
+        import soundfile as sf, io
+        pcm_np, _ = sf.read(io.BytesIO(wav_bytes), dtype="int16")
+        reply_pcm = pcm_np.tobytes()
     except Exception as exc:
-        reply_pcm = b""  # empty audio
-        print(f"Deepgram TTS failed: {exc}")
+        reply_pcm = b""
+        print(f"Groq TTS failed: {exc}")
 
     return reply_text, reply_pcm
 

--- a/groq_tts.py
+++ b/groq_tts.py
@@ -1,0 +1,30 @@
+import os
+from typing import Optional
+from groq import Groq
+
+from config_defaults import TTSConfig
+
+_client: Optional[Groq] = None
+
+def get_client() -> Groq:
+    global _client
+    if _client is None:
+        api_key = os.environ.get("GROQ_API_KEY")
+        if not api_key:
+            raise EnvironmentError("GROQ_API_KEY environment variable not set")
+        _client = Groq(api_key=api_key)
+    return _client
+
+
+def synthesize_speech(text: str, voice: str = TTSConfig.VOICE_NAME,
+                      model: str = TTSConfig.MODEL_NAME,
+                      response_format: str = TTSConfig.RESPONSE_FORMAT) -> bytes:
+    """Generate speech audio bytes from text using Groq Play-AI TTS."""
+    client = get_client()
+    response = client.audio.speech.create(
+        model=model,
+        voice=voice,
+        input=text,
+        response_format=response_format,
+    )
+    return response.content

--- a/main.py
+++ b/main.py
@@ -120,7 +120,7 @@ def get_todays_free_slots():
             CURRENT_METRICS["calendar_errors"] += 1
         return []
     return [f"{s[0].strftime('%I:%M %p')} - {s[1].strftime('%I:%M %p')}" for s in slots]
-VOICE = "shimmer"
+VOICE = "Cheyenne-PlayAI"
 LOG_EVENT_TYPES = [
     "response.content.done",
     "rate_limits.updated",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ google-auth-httplib2 = "0.2.0"
 guardrails-ai = "0.6.6"
 SQLAlchemy = "2.0.30"
 sounddevice = "0.4.6"
+groq = "0.29.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
## Summary
- add Groq PlayAI text-to-speech helper
- default to PlayAI voices in config, main app and launcher
- replace Deepgram voice list with PlayAI voices
- update demo pipelines to call Groq TTS
- document new voice options in the configuration guide
- update README introduction

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile groq_tts.py main.py app_launcher.py config_defaults.py demo_mode_deepgram_voice_agent.py demo_mode_GROQ_deepgram_voice_agent.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_688d112e833c832d8549aac9dc94c097