### PR TITLE
Fix TTS response handling and provider names

### DIFF
--- a/WORKING DEMOS/demo_mode_deepgram_voice_agent.py
+++ b/WORKING DEMOS/demo_mode_deepgram_voice_agent.py
@@ -244,7 +244,7 @@ class DeepgramVoiceAgentPipeline:
                     pass
             
             # LLM configuration (we'll inject strategic context)
-            options.agent.think.provider.type = "open_ai"  # Deepgram supports OpenAI-compatible APIs
+            options.agent.think.provider.type = "openai"  # Deepgram supports OpenAI-compatible APIs
             options.agent.think.provider.model = "gpt-4o-mini"
             options.agent.think.provider.temperature = 0.7
             

--- a/demo_mode_GROQ_deepgram_voice_agent.py
+++ b/demo_mode_GROQ_deepgram_voice_agent.py
@@ -654,7 +654,7 @@ class DeepgramVoiceAgentPipeline:
                 try:
                     # Correct BYO LLM configuration using dictionary syntax
                     # Provider configuration (using dictionary access)
-                    options.agent.think.provider["type"] = "open_ai"
+                    options.agent.think.provider["type"] = "openai"
                     options.agent.think.provider["model"] = LLMConfig.MODEL_NAME
                     options.agent.think.provider["temperature"] = LLMConfig.TEMPERATURE
                     
@@ -671,7 +671,7 @@ class DeepgramVoiceAgentPipeline:
                     print(f"  ❌ BYO LLM configuration failed: {e1}")
                     print("  ⚠️ Falling back to standard Deepgram LLM")
                     # Force fallback to standard LLM configuration using dictionary syntax
-                    options.agent.think.provider["type"] = "open_ai"
+                    options.agent.think.provider["type"] = "openai"
                     options.agent.think.provider["model"] = LLMConfig.DEEPGRAM_LLM_MODEL
                     options.agent.think.provider["temperature"] = LLMConfig.TEMPERATURE
                     print("  ✅ Standard LLM fallback configured")
@@ -679,19 +679,19 @@ class DeepgramVoiceAgentPipeline:
             else:
                 print("Using standard Deepgram LLM...")
                 try:
-                    options.agent.think.provider["type"] = "open_ai"  # Deepgram's default
+                    options.agent.think.provider["type"] = "openai"  # Deepgram's default
                     options.agent.think.provider["model"] = LLMConfig.DEEPGRAM_LLM_MODEL
                     options.agent.think.provider["temperature"] = LLMConfig.TEMPERATURE
                     print(f"  ✅ Standard LLM configured: {LLMConfig.DEEPGRAM_LLM_MODEL}")
                 except Exception as e:
                     print(f"  ❌ Error configuring standard LLM: {e}")
                     # Ultimate fallback - minimal configuration
-                    options.agent.think.provider["type"] = "open_ai"
+                    options.agent.think.provider["type"] = "openai"
                     options.agent.think.provider["model"] = "gpt-4o-mini"
                     print("  ✅ Using minimal fallback LLM configuration")
             
             # TTS configuration now uses Groq Play-AI
-            options.agent.speak.provider.type = "open_ai"
+            options.agent.speak.provider.type = "openai"
             voice_name = os.getenv("AGENT_VOICE_NAME", "Cheyenne-PlayAI")
             options.agent.speak.provider.model = voice_name
             

--- a/demo_mode_deepgram_voice_agent.py
+++ b/demo_mode_deepgram_voice_agent.py
@@ -247,12 +247,12 @@ class DeepgramVoiceAgentPipeline:
                     pass
             
             # LLM configuration (we'll inject strategic context)
-            options.agent.think.provider.type = "open_ai"  # Deepgram supports OpenAI-compatible APIs
+            options.agent.think.provider.type = "openai"  # Deepgram supports OpenAI-compatible APIs
             options.agent.think.provider.model = "gpt-4o-mini"
             options.agent.think.provider.temperature = 0.7
             
             # TTS configuration using Groq Play-AI
-            options.agent.speak.provider.type = "open_ai"
+            options.agent.speak.provider.type = "openai"
             voice_name = os.getenv("AGENT_VOICE_NAME", "Cheyenne-PlayAI")
             options.agent.speak.provider.model = voice_name
             

--- a/groq_tts.py
+++ b/groq_tts.py
@@ -27,4 +27,6 @@ def synthesize_speech(text: str, voice: str = TTSConfig.VOICE_NAME,
         input=text,
         response_format=response_format,
     )
-    return response.content
+    # `BinaryAPIResponse` does not expose a `content` attribute. Use `read()`
+    # to obtain the binary audio bytes from the response object.
+    return response.read()


### PR DESCRIPTION
## Summary
- correct Groq speech synthesis to use `.read()` instead of missing `.content`
- update provider type from `open_ai` to `openai` for TTS/LLM configuration

## Testing
- `python -m py_compile groq_tts.py demo_mode_GROQ_deepgram_voice_agent.py demo_mode_deepgram_voice_agent.py "WORKING DEMOS/demo_mode_deepgram_voice_agent.py"`

------
https://chatgpt.com/codex/tasks/task_e_688d1719ad8c832da91efe8f63b92cb5